### PR TITLE
fix: standardise hierarchy env var across apps

### DIFF
--- a/workload/core/3-smart-cache-graph/server/patches/config/config.ttl
+++ b/workload/core/3-smart-cache-graph/server/patches/config/config.ttl
@@ -120,7 +120,7 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
 
     # ABAC endpoint for user attributes
     authz:attributesURL <env:USER_ATTRIBUTES_URL>;
-    authz:hierarchiesURL <env:ABAC_HIERARCHIES_URL>;
+    authz:hierarchiesURL <env:ATTRIBUTE_HIERARCHY_URL>;
     .
 
 ## Storage of data in memory.
@@ -236,7 +236,7 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
 
     # ABAC endpoint for user attributes
     authz:attributesURL <env:USER_ATTRIBUTES_URL>;
-    authz:hierarchiesURL <env:ABAC_HIERARCHIES_URL>;
+    authz:hierarchiesURL <env:ATTRIBUTE_HIERARCHY_URL>;
     .
 
 ## Storage of data in memory.

--- a/workload/core/3-smart-cache-graph/server/patches/config/server.env
+++ b/workload/core/3-smart-cache-graph/server/patches/config/server.env
@@ -1,5 +1,5 @@
 USER_ATTRIBUTES_URL=http://access-api.tc-system.svc.cluster.local:8080/users/lookup/{user}
-ABAC_HIERARCHIES_URL=http://access-api.tc-system.svc.cluster.local:8080/hierarchies/lookup/{name}
+ATTRIBUTE_HIERARCHY_URL=http://access-api.tc-system.svc.cluster.local:8080/hierarchies/lookup/{name}
 JWKS_URL=https://YOUR.AUTH.DOMAIN.HERE.COM/keys
 JAVA_OPTIONS=-Xmx5120m -Xms2048m
 


### PR DESCRIPTION
This implements the variable changes to standardise ABAC environment variables between SCS and SCG following issue raised by customer.

Already completed in base/profile manifests from release v1.21.0+