### PR TITLE
fix: manifest releases greater than v2.0.1 will no longer create this secret

### DIFF
--- a/workload/core/2-access/kustomization.yaml
+++ b/workload/core/2-access/kustomization.yaml
@@ -21,7 +21,6 @@ secretGenerator:
       disableNameSuffixHash: true
     literals:
       - password=change.to.access.api.mongodb.password
-    behavior: replace
 
 # Merge/Replace config(s) tailored for your environment
 configMapGenerator:


### PR DESCRIPTION
This allows flexibility in how secrets are created by the system integrator without conflicting with resources created in the OSS profile